### PR TITLE
feat : 게시글 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/example/board/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/board/domain/post/controller/PostController.java
@@ -1,9 +1,9 @@
 package com.example.board.domain.post.controller;
 
 import com.example.board.domain.post.dto.PostCreateRequest;
+import com.example.board.domain.post.dto.PostDetailResponse;
 import com.example.board.domain.post.dto.PostListResponse;
 import com.example.board.domain.post.dto.PostUpdateRequest;
-import com.example.board.domain.post.entity.Post;
 import com.example.board.domain.post.service.PostService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
@@ -67,7 +67,7 @@ public class PostController {
     // 게시글 상세보기
     @GetMapping("/{postId}")
     public String detailPost(@PathVariable(name = "postId") Long postId, Model model) {
-        Post post = postService.getPost(postId);
+        PostDetailResponse post = postService.getPost(postId);
 
         model.addAttribute("post", post);
 
@@ -77,7 +77,7 @@ public class PostController {
     // 게시글 수정 페이지 이동
     @GetMapping("/{postId}/updateForm")
     public String updateForm(@PathVariable(name = "postId") Long postId, Model model) {
-        Post post = postService.getPost(postId);
+        PostDetailResponse post = postService.getPost(postId);
 
         model.addAttribute("post", post);
 

--- a/src/main/java/com/example/board/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/board/domain/post/controller/PostController.java
@@ -108,4 +108,12 @@ public class PostController {
 
         return "redirect:/posts";
     }
+
+    // 게시글 좋아요
+    @PostMapping("{postId}/like")
+    public String likePost(@PathVariable(name = "postId") Long postId) {
+        postService.like(postId);
+
+        return "redirect:/posts/" + postId;
+    }
 }

--- a/src/main/java/com/example/board/domain/post/dao/CustomPostDao.java
+++ b/src/main/java/com/example/board/domain/post/dao/CustomPostDao.java
@@ -1,5 +1,6 @@
 package com.example.board.domain.post.dao;
 
+import com.example.board.domain.post.dto.PostDetailResponse;
 import com.example.board.domain.post.dto.PostListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,5 +8,7 @@ import org.springframework.data.domain.Pageable;
 public interface CustomPostDao {
 
     Page<PostListResponse> findPostList(Long categoryId, String keyword, Pageable pageable);
+
+    PostDetailResponse findPost(Long postId);
 
 }

--- a/src/main/java/com/example/board/domain/post/dao/CustomPostDaoImpl.java
+++ b/src/main/java/com/example/board/domain/post/dao/CustomPostDaoImpl.java
@@ -1,8 +1,12 @@
 package com.example.board.domain.post.dao;
 
+import static com.example.board.domain.comment.entity.QComment.comment;
 import static com.example.board.domain.post.entity.QPost.post;
 
+import com.example.board.domain.comment.entity.Comment;
+import com.example.board.domain.post.dto.PostDetailResponse;
 import com.example.board.domain.post.dto.PostListResponse;
+import com.example.board.domain.post.dto.QPostDetailResponse;
 import com.example.board.domain.post.dto.QPostListResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -18,6 +22,31 @@ import org.springframework.stereotype.Repository;
 public class CustomPostDaoImpl implements CustomPostDao {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public PostDetailResponse findPost(Long postId) {
+        PostDetailResponse response = queryFactory
+            .select(
+                new QPostDetailResponse(
+                    post.id,
+                    post.title,
+                    post.content,
+                    post.createdAt,
+                    post.likes,
+                    post.category.name,
+                    post.member.email
+                )
+            ).from(post)
+            .where(post.id.eq(postId))
+            .fetchOne();
+
+        List<Comment> comments = queryFactory.selectFrom(comment)
+            .where(comment.post.id.eq(postId))
+            .fetch();
+
+        response.setComments(comments);
+        return response;
+    }
 
     @Override
     public Page<PostListResponse> findPostList(Long categoryId, String keyword, Pageable pageable) {

--- a/src/main/java/com/example/board/domain/post/dao/PostDao.java
+++ b/src/main/java/com/example/board/domain/post/dao/PostDao.java
@@ -1,5 +1,6 @@
 package com.example.board.domain.post.dao;
 
+import com.example.board.domain.post.dto.PostDetailResponse;
 import com.example.board.domain.post.dto.PostListResponse;
 import com.example.board.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
@@ -14,4 +15,6 @@ public interface PostDao extends JpaRepository<Post, Long>, CustomPostDao {
 
     @Override
     Page<PostListResponse> findPostList(Long categoryId, String keyword, Pageable pageable);
+
+    PostDetailResponse findPost(Long postId);
 }

--- a/src/main/java/com/example/board/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/board/domain/post/dto/PostDetailResponse.java
@@ -1,0 +1,39 @@
+package com.example.board.domain.post.dto;
+
+import com.example.board.domain.comment.entity.Comment;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PostDetailResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private Long likes;
+    private String category;
+    private String author;
+    private List<Comment> comments;
+
+    @QueryProjection
+    public PostDetailResponse(Long id, String title, String content, LocalDateTime createdAt,
+        Long likes, String category, String author) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.likes = likes;
+        this.category = category;
+        this.author = author;
+    }
+
+    public void setComments(List<Comment> comments) {
+        this.comments = comments;
+    }
+
+}

--- a/src/main/java/com/example/board/domain/post/entity/Post.java
+++ b/src/main/java/com/example/board/domain/post/entity/Post.java
@@ -36,7 +36,7 @@ public class Post extends BaseEntity {
 
     @ColumnDefault("0")
     @Min(0)
-    private Long likes;
+    private long likes;
 
     @ManyToOne(cascade = {CascadeType.PERSIST}, fetch = FetchType.LAZY, optional = false)
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))

--- a/src/main/java/com/example/board/domain/post/entity/Post.java
+++ b/src/main/java/com/example/board/domain/post/entity/Post.java
@@ -67,4 +67,8 @@ public class Post extends BaseEntity {
             this.content = request.getContent();
         }
     }
+
+    public void increaseLike() {
+        this.likes++;
+    }
 }

--- a/src/main/java/com/example/board/domain/post/service/PostService.java
+++ b/src/main/java/com/example/board/domain/post/service/PostService.java
@@ -7,6 +7,7 @@ import com.example.board.domain.member.entity.Member;
 import com.example.board.domain.member.entity.MemberRoleEnum;
 import com.example.board.domain.post.dao.PostDao;
 import com.example.board.domain.post.dto.PostCreateRequest;
+import com.example.board.domain.post.dto.PostDetailResponse;
 import com.example.board.domain.post.dto.PostListResponse;
 import com.example.board.domain.post.dto.PostUpdateRequest;
 import com.example.board.domain.post.entity.Post;
@@ -43,9 +44,8 @@ public class PostService {
 
     // 게시글 단건 조회
     @Transactional(readOnly = true)
-    public Post getPost(Long postId) {
-        Post post = findPostById(postId);
-        return post;
+    public PostDetailResponse getPost(Long postId) {
+        return postDao.findPost(postId);
     }
 
     // 게시글 저장

--- a/src/main/java/com/example/board/domain/post/service/PostService.java
+++ b/src/main/java/com/example/board/domain/post/service/PostService.java
@@ -98,6 +98,13 @@ public class PostService {
         }
     }
 
+    // 게시글 좋아요
+    @Transactional
+    public void like(Long postId) {
+        Post post = findPostById(postId);
+        post.increaseLike();
+    }
+
     private Post findPostById(Long postId) {
         return postDao.findById(postId).orElseThrow(
             () -> new NotFoundPostException("존재하지 않는 게시글입니다.")

--- a/src/main/resources/templates/posts/detail.html
+++ b/src/main/resources/templates/posts/detail.html
@@ -27,10 +27,10 @@
     <h1 class="text-3xl flex items-center">[[${post.id}]]번 게시글</h1>
     <div class="flex-grow"></div>
     <div class="flex items-center"><span class="badge text-bg-primary mr-2">카테고리</span>
-      [[${post.category.name}]]
+      [[${post.category}]]
     </div>
     <div class="flex items-center"><span class="badge text-bg-primary ml-3 mr-2">작성자</span>
-      [[${post.member.email}]]
+      [[${post.author}]]
     </div>
   </div>
 
@@ -41,15 +41,26 @@
     [[${#temporals.format(post.createdAt, 'YYYY-MM-dd HH:mm')}]]
   </div>
 
+  <div class="self-center">
+    <form th:action="@{/posts/{postId}/like(postId=${post.id})}" method="post" class="m-0">
+      <button class="btn btn-danger text-lg" type="submit"
+              th:disabled="${!(#authorization.expression('hasAuthority(''ADMIN'')') ||
+	                                (#authorization.expr('isAuthenticated()')&&
+	                                #authentication.principal != null))}">
+        좋아요 : [[${post.likes}]]
+      </button>
+    </form>
+  </div>
+
 
 </div>
 <div class="container mx-auto flex gap-3 justify-end my-4 items-center px-4">
   <form th:action="@{/posts/{postId}/updateForm(postId=${post.id})}" method="get" class="m-0">
     <button class="btn btn-warning" type="submit"
             th:disabled="${!(#authorization.expression('hasAuthority(''ADMIN'')') ||
-	                                (#authorization.expr('isAuthenticated()') && post.member != null &&
+	                                (#authorization.expr('isAuthenticated()') &&
 	                                #authentication.principal != null &&
-	                                post.member.email == #authentication.principal.username))}">
+	                                post.author == #authentication.principal.username))}">
       수정하기
     </button>
   </form>
@@ -57,9 +68,9 @@
         method="post" class="m-0">
     <button class="btn btn-danger" type="button"
             th:disabled="${!(#authorization.expression('hasAuthority(''ADMIN'')') ||
-	                                (#authorization.expr('isAuthenticated()') && post.member != null &&
+	                                (#authorization.expr('isAuthenticated()') &&
 	                                #authentication.principal != null &&
-	                                post.member.email == #authentication.principal.username))}"
+	                                post.author == #authentication.principal.username))}"
             onclick="validateBoardDelete();">
       삭제하기
     </button>
@@ -68,7 +79,7 @@
         method="post" class="m-0">
     <button class="btn btn-success" type="submit"
             th:disabled="${!(#authorization.expression('hasAuthority(''ADMIN'')') ||
-	                                (#authorization.expr('isAuthenticated()') && post.member != null &&
+	                                (#authorization.expr('isAuthenticated()') &&
 	                                #authentication.principal != null))}">
       게시글 신고
     </button>

--- a/src/main/resources/templates/posts/updateForm.html
+++ b/src/main/resources/templates/posts/updateForm.html
@@ -36,7 +36,7 @@
       <div class="mb-3">
         <label class="form-label" for="type">Type</label>
         <select class="form-control" id="type" name="type">
-          <option value="" disabled selected>[[${post.category.name}]]</option>
+          <option value="" disabled selected>[[${post.category}]]</option>
         </select>
       </div>
       <button class="btn btn-primary" type="submit">


### PR DESCRIPTION
### 이슈 번호
- #9 

<br>

### 작업 내용
- [x] Entity
   - [x] `@ColumnDefault` 어노테이션 적용을 위하여 좋아요 수 필드 Long -> long 원시타입 변경
   - [x] 좋아요 기능 호출 시, 좋아요 필드 값 1 증가 메서드 구현 

- [x] Dao
  - [x] 게시글 상세보기 페이지에서 불필요한 쿼리 호출(회원조회, 종속된 답변 조회 쿼리 )에 대하여 QueryDsl을 이용하여 단건조회 쿼리 구현
